### PR TITLE
Fix bug in editing questions and answers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,4 +43,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/Quizhub.java
+++ b/src/main/java/Quizhub.java
@@ -50,6 +50,6 @@ public class Quizhub {
     }
 
     public static void main(String[] args) {
-         new Quizhub("tasklist.txt").run();
+        new Quizhub("tasklist.txt").run();
     }
 }

--- a/src/main/java/quizhub/command/CommandEdit.java
+++ b/src/main/java/quizhub/command/CommandEdit.java
@@ -10,14 +10,22 @@ public class CommandEdit extends Command {
     private int qnIndex;
     private String newDescription;
     private String newAnswer;
+
+    private String GetContentFromUserInput(String userInput, String keyWord) throws ArrayIndexOutOfBoundsException {
+        String content;
+        content = userInput.split(keyWord)[1].strip();
+        if (content.isEmpty()) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        return content;
+    }
+
     public CommandEdit(String userInput) {
         super(CommandType.EDIT);
         String[] editDetails;
-        String[] editInfo;
         try {
-            editDetails = userInput.split("edit")[1].strip().split("/");
-            qnIndex = Integer.parseInt(editDetails[0].strip());
-            editInfo = editDetails[1].strip().split(" ");
+            editDetails = userInput.split(" ");
+            qnIndex = Integer.parseInt(editDetails[1].strip());
         } catch (NumberFormatException incompleteCommand) {
             System.out.println("    Ono! You did not indicate the index of the question you wish to edit :<");
             System.out.println("    Please format your input as edit [question number] /description [description] " +
@@ -30,16 +38,13 @@ public class CommandEdit extends Command {
             return;
         }
         try {
-            String editCriteria = editInfo[0].strip();
-            String editContent = editInfo[1].strip();
+            String editCriteria = editDetails[2].strip();
             switch (editCriteria){
-            case "description":
-                newDescription = editContent;
-                newAnswer = "";
+            case "/description":
+                newDescription = GetContentFromUserInput(userInput, "/description");
                 break;
-            case "answer":
-                newDescription = "";
-                newAnswer = editContent;
+            case "/answer":
+                newAnswer = GetContentFromUserInput(userInput, "/answer");
                 break;
             default:
                 throw new ArrayIndexOutOfBoundsException();

--- a/src/main/java/quizhub/command/CommandHelp.java
+++ b/src/main/java/quizhub/command/CommandHelp.java
@@ -24,7 +24,7 @@ public class CommandHelp extends Command{
         System.out.println("    3. list - shows the list of questions and answers");
         System.out.println("    4. delete [question number] - deletes the question and answer at the specified number");
         System.out.println("    5. find /[description] - displays all questions that contains the the specified description");
-        System.out.println("    6. edit [question number] /question - edits the question with the specified number");
+        System.out.println("    6. edit [question number] /description - edits the question with the specified number");
         System.out.println("    7. edit [question number] /answer - edits the answer to the question with the specified number");
         System.out.println("    8. start - starts the quiz");
         System.out.println("    9. bye - exits the program");  

--- a/src/main/java/quizhub/question/Question.java
+++ b/src/main/java/quizhub/question/Question.java
@@ -76,7 +76,7 @@ public class Question {
         return qnType;
     }
     public void editQuestion(String newDescription, String newAnswer){
-        if(!newDescription.isEmpty()){
+        if(null != newDescription){
             this.description = newDescription;
         }
     }

--- a/src/main/java/quizhub/question/ShortAnsQn.java
+++ b/src/main/java/quizhub/question/ShortAnsQn.java
@@ -24,7 +24,7 @@ public class ShortAnsQn extends Question {
     @Override
     public void editQuestion(String newDescription, String newAnswer) {
         super.editQuestion(newDescription, newAnswer);
-        if(!newAnswer.isEmpty()){
+        if(null != newAnswer){
             this.answer = newAnswer;
         }
     }

--- a/src/main/java/quizhub/questionlist/QuestionList.java
+++ b/src/main/java/quizhub/questionlist/QuestionList.java
@@ -334,8 +334,6 @@ public class QuestionList {
             String correctAnswer = getAnswerByIndex(i + 1).strip(); // Get the correct answer by index
             String userAnswer = ui.getUserInput().strip();
 
-            System.out.println(correctAnswer + "\n" + userAnswer);
-
             if (userAnswer.equalsIgnoreCase(correctAnswer)) {
                 System.out.println("    Correct!");
                 correctAnswers++;


### PR DESCRIPTION
closes #40 

Fix edit question command logic.
Split command by white spaces to find the keyword.
Split the original command again by the keyword to get the content.